### PR TITLE
preserve oauth scopes

### DIFF
--- a/libweasyl/alembic/versions/3ce027aa9bc4_track_oauth_consumer_app_homepages.py
+++ b/libweasyl/alembic/versions/3ce027aa9bc4_track_oauth_consumer_app_homepages.py
@@ -1,0 +1,29 @@
+"""track oauth consumer app homepages
+
+Provide a way for OAuth2 consumer applications to
+register the homepage of their app, giving us
+a way to find out where our API's are being used
+as well as facilitating the possibility of featuring
+3rd party projects.
+
+Revision ID: 3ce027aa9bc4
+Revises: abac1922735d
+Create Date: 2016-05-09 16:02:48.478539
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3ce027aa9bc4'
+down_revision = 'abac1922735d'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.add_column('oauth_consumers', sa.Column('homepage', postgresql.TEXT(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('oauth_consumers', 'homepage')

--- a/libweasyl/alembic/versions/3ce027aa9bc4_track_oauth_consumer_app_homepages.py
+++ b/libweasyl/alembic/versions/3ce027aa9bc4_track_oauth_consumer_app_homepages.py
@@ -22,7 +22,7 @@ from sqlalchemy.dialects import postgresql
 
 
 def upgrade():
-    op.add_column('oauth_consumers', sa.Column('homepage', postgresql.TEXT(), nullable=True))
+    op.add_column('oauth_consumers', sa.Column('homepage', postgresql.TEXT(), nullable=False))
 
 
 def downgrade():

--- a/libweasyl/conftest.py
+++ b/libweasyl/conftest.py
@@ -29,10 +29,13 @@ def setup(request):
 @pytest.fixture(autouse=True)
 def staticdir(tmpdir):
     tmpdir = tmpdir.join('libweasyl-staticdir')
+    # probably a better way to do this
+    staff_file = '../config/weasyl-staff.yaml'
     configure_libweasyl(
         dbsession=sessionmaker,
         not_found_exception=NotFound,
         base_file_path=tmpdir.strpath,
+        staff_config_path=staff_file,
         media_link_formatter_callback=media_link_formatter.format_media_link,
     )
     return tmpdir

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -484,7 +484,7 @@ oauth_consumers = Table(
     Column('scopes', ARRAY(Text()), nullable=False),
     Column('redirect_uris', ARRAY(Text()), nullable=False),
     Column('client_secret', String(length=64), nullable=False),
-    Column('homepage', Text(), nullable=True),
+    Column('homepage', Text(), nullable=False),
     default_fkey(['ownerid'], ['login.userid'], name='oauth_consumers_owner_fkey'),
 )
 

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -484,6 +484,7 @@ oauth_consumers = Table(
     Column('scopes', ARRAY(Text()), nullable=False),
     Column('redirect_uris', ARRAY(Text()), nullable=False),
     Column('client_secret', String(length=64), nullable=False),
+    Column('homepage', Text(), nullable=True),
     default_fkey(['ownerid'], ['login.userid'], name='oauth_consumers_owner_fkey'),
 )
 

--- a/libweasyl/oauth.py
+++ b/libweasyl/oauth.py
@@ -114,7 +114,10 @@ class WeasylValidator(RequestValidator):
         if not bearer:
             return False
         scopes = set(scopes)
-        if (scopes & set(bearer.scopes)) != scopes:
+        bearer_scopes = set(bearer.scopes)
+        # bearer only valid if it satisfied all scopes requested
+        # wholesite permission implicitly grants all others
+        if 'wholesite' not in bearer_scopes and (scopes & bearer_scopes) != scopes:
             return False
         request.userid = bearer.userid
         return True

--- a/libweasyl/oauth.py
+++ b/libweasyl/oauth.py
@@ -6,26 +6,14 @@ from libweasyl import security
 from libweasyl import staff
 from libweasyl.models.api import OAuthBearerToken, OAuthConsumer
 
-SCOPES = [
-    {
-        'name': 'wholesite',
-        'description': 'FULL CONTROL - Note that this means the application can '
-                       'perform almost any action as if you were logged in!',
-    },
-    {
-        'name': 'identity',
-        'description': 'Permission to retrieve your weasyl username and account number',
-    },
-    {
-        'name': 'notifications',
-        'description': 'Access to view your submission inbox, as well as notification counts '
-                       'for comments, favs, messages, etc.',
-    },
-    {
-        'name': 'favorite',
-        'description': 'The ability to favorite and unfavorite submissions',
-    },
-]
+SCOPES = {
+    'wholesite': 'FULL CONTROL - Note that this means the application can '
+                 'perform almost any action as if you were logged in!',
+    'identity': 'Permission to retrieve your weasyl username and account number',
+    'notifications': 'Access to view your submission inbox, as well as notification counts '
+                     'for comments, favs, messages, etc.',
+    'favorite': 'The ability to favorite and unfavorite submissions',
+}
 
 
 class WeasylValidator(RequestValidator):
@@ -251,8 +239,8 @@ def get_allowed_scopes(userid):
     :param userid: the userid of the application owner
     :return: a list of scopes
     """
-    allowed = SCOPES
+    allowed = SCOPES.copy()
     # only trusted individuals should be allowed to use the "wholesite" oauth grant
-    if userid not in staff.ADMINS | staff.MODS | staff.DEVELOPERS:
-        allowed = [scope for scope in allowed if scope['name'] != 'wholesite']
+    if userid not in staff.MODS | staff.DEVELOPERS:
+        allowed.pop('wholesite', None)
     return allowed

--- a/libweasyl/oauth.py
+++ b/libweasyl/oauth.py
@@ -176,11 +176,13 @@ def revoke_consumers_for_user(userid, clientids):
 def register_client(userid, name, scopes, redirects, homepage):
     """
     Register an application as an OAuth2 consumer
-    :param userid: the user registering this application
-    :param name: the name of the application
-    :param scopes: a list of the scopes registered for this application
-    :param redirects: allowed redirect URIs for this application
-    :param homepage: The url of the project this consumer is for (optional)
+
+    Parameters:
+        userid (int): the user registering this application
+        name (str): the name of the application
+        scopes (list of str): a list of the scopes registered for this application
+        redirects (list of str): allowed redirect URIs for this application
+        homepage (str): The url of the project this consumer is for (optional)
     """
 
     allowed_scopes = set(get_allowed_scopes(userid).keys())
@@ -217,8 +219,10 @@ def get_registered_applications(userid):
 def remove_clients(userid, clients):
     """
     Delete a set of OAuth2 applications associated with a user.
-    :param userid: the user making the request
-    :param clients: a list of client ID's owned by this user to be removed
+
+    Parameters:
+        userid (int): the user making the request
+        clients (list of int): a list of client ID's owned by this user to be removed
     """
     q = (OAuthConsumer.query
          .filter_by(ownerid=userid)
@@ -231,8 +235,10 @@ def renew_client_secrets(userid, clients):
     Iterates over client IDs of OAuth2 applications
     and assigns each one a new client secret.
     To be used in the event of an oopsie.
-    :param userid: the user making the request
-    :param clients: a list of client ID's owned by this user to be renewed
+
+    Parameters:
+        userid (int): the user making the request
+        clients (list of int): a list of client ID's owned by this user to be renewed
     """
     for cid in clients:
         q = (OAuthConsumer.query
@@ -245,8 +251,12 @@ def renew_client_secrets(userid, clients):
 def get_allowed_scopes(userid):
     """
     Get a list of oauth scopes this user is allowed to request
-    :param userid: the userid of the application owner
-    :return: a list of scopes
+
+    Parameters:
+        userid (int): the userid of the application owner
+        
+    Returns:
+        a list of scopes
     """
     allowed = SCOPES.copy()
     # only trusted individuals should be allowed to use the "wholesite" oauth grant

--- a/libweasyl/oauth.py
+++ b/libweasyl/oauth.py
@@ -181,8 +181,9 @@ def register_client(userid, name, scopes, redirects, homepage):
     """
 
     session = OAuthConsumer.dbsession
+    clientid = "{}_{}".format(userid, security.generate_key(16))
     new_consumer = OAuthConsumer(
-        clientid=security.generate_key(32),
+        clientid=clientid,
         description=name,
         ownerid=userid,
         grant_type="authorization_code",

--- a/libweasyl/oauth.py
+++ b/libweasyl/oauth.py
@@ -15,6 +15,8 @@ SCOPES = {
     'favorite': 'The ability to favorite and unfavorite submissions',
 }
 
+_SECRET_LENGTH = 64
+
 
 class WeasylValidator(RequestValidator):
     def _get_client(self, client_id):
@@ -178,7 +180,13 @@ def register_client(userid, name, scopes, redirects, homepage):
     :param name: the name of the application
     :param scopes: a list of the scopes registered for this application
     :param redirects: allowed redirect URIs for this application
+    :param homepage: The url of the project this consumer is for (optional)
     """
+
+    allowed_scopes = set(get_allowed_scopes(userid).keys())
+    scopes = set(scopes) & allowed_scopes
+    if not scopes:
+        raise ValueError("Must contain at least one scope")
 
     session = OAuthConsumer.dbsession
     clientid = "{}_{}".format(userid, security.generate_key(16))
@@ -190,7 +198,7 @@ def register_client(userid, name, scopes, redirects, homepage):
         response_type="code",
         scopes=scopes,
         redirect_uris=redirects,
-        client_secret=security.generate_key(64),
+        client_secret=security.generate_key(_SECRET_LENGTH),
         homepage=homepage,
     )
     session.add(new_consumer)

--- a/libweasyl/test/test_oauth.py
+++ b/libweasyl/test/test_oauth.py
@@ -1,0 +1,76 @@
+from libweasyl.test import common
+
+import pytest
+
+from libweasyl import oauth
+
+
+def test_oauth_register_app(db):
+    user = common.make_user(db)
+    appname = "testclient"
+    oauth.register_client(user.userid, appname, ['identity'], ['http://example.com'], '')
+    oauth.register_client(user.userid, appname, ['favorite'], ['http://example.com'], '')
+    registered = oauth.get_registered_applications(user.userid)
+    assert len(registered) == 2
+    assert registered[0].description == appname
+
+
+@pytest.mark.parametrize(('in_scopes', 'out_scopes'), [
+    (['identity'], ['identity']),
+    (['identity', 'identity'], ['identity']),
+    (['identity', 'fake_scope'], ['identity']),
+    (['wholesite', 'favorite'], ['favorite']),
+])
+def test_oauth_invalid_scopes(db, in_scopes, out_scopes):
+    """
+    test that invalid scopes are not persisted to the database
+    for the purpose of this test wholesite is an invalid scope
+    because the generated user should not be in the list of staff.
+    """
+    user = common.make_user(db)
+    oauth.register_client(user.userid, "test", in_scopes, ['http://example.com'], '')
+    app = oauth.get_registered_applications(user.userid)[0]
+    assert app.scopes == out_scopes
+
+
+def test_oauth_register_consumer(db):
+    """
+    test that we can generate and retrieve an auth token
+    """
+    appowner = common.make_user(db)
+    appuser = common.make_user(db)
+    redirect = 'https://example.com'
+    oauth.register_client(appowner.userid, "test", ['identity'], [redirect], '')
+    app = oauth.get_registered_applications(appowner.userid)[0]
+    headers, body, response_code = oauth.server.create_authorization_response(
+        'https://weasyl.com/api/oauth/authorize',
+        'POST',
+        {
+            'response_type': 'code',
+            'client_id': app.clientid,
+            'redirect_uri': redirect,
+            'state': 'clientstate',
+        },
+        None,
+        ['identity'],
+        {"userid": appuser.userid},
+    )
+    loc = headers['Location']
+    # if code stops being the last parameter passed back then i'm sorry
+    code = loc[loc.find("code=")+5:]
+    oauth.server.create_token_response(
+        'https://weasyl.com/api/oauth/token',
+        'POST',
+        {
+            "code": code,
+            "grant_type": "authorization_code",
+            "client_id": app.clientid,
+            "client_secret": app.client_secret,
+            "redirect_uri": redirect
+        },
+        None,
+        {"userid": appuser.userid},
+    )
+    consumers = oauth.get_consumers_for_user(appuser.userid)
+    assert len(consumers) == 1
+    assert consumers[0].owner.profile.userid == appowner.userid


### PR DESCRIPTION
Changes related to Weasyl/weasyl#15
- assure OAuth2 clients with wholesite auth scope still work with new auth scope levels
- add a column to the oauth_consumers table to allow us to record the homepage of registered applications, should they have one.
