### PR TITLE
Add a .travis.yml configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: python
+# Run on Travis CI's docker infrastructure
+sudo: false
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27 CC=gcc
+    - python: 3.5
+      env: TOXENV=py35 CC=gcc
+    - python: 2.7
+      env: TOXENV=py27 CC=clang
+    - python: 3.5
+      env: TOXENV=py35 CC=clang
+    - python: 2.7
+      env: TOXENV=pep8
+    - python: 3.5
+      env: TOXENV=py3pep8
+
+addons:
+    postgresql: "9.4"
+
+services:
+    - memcached
+    - postgresql
+
+before_install:
+    - pip install -U pip
+    - pip --version
+    - export VE=$VIRTUAL_ENV  # Use the virtual environment travis provides.
+    - cp pip.conf $VE
+
+install:
+    - createdb -E UTF8 -O travis weasyl_test
+    - make .stamp-ve  # Setup up our own ve.
+
+script:
+    - make test
+
+branches:
+  only:
+    - master
+

--- a/libweasyl/text.py
+++ b/libweasyl/text.py
@@ -12,7 +12,10 @@ from .legacy import login_name
 try:
     from html.parser import locatestarttagend
 except ImportError:
-    from HTMLParser import locatestarttagend
+    try:
+        from html.parser import locatestarttagend_tolerant as locatestarttagend
+    except ImportError:
+        from HTMLParser import locatestarttagend
 
 
 def slug_for(title):


### PR DESCRIPTION
Also fixes an issue with `html.parser` in 3.5.

Tested by watching the travis CI consoles for my fork.

Not sure about the test matrix. Unfortunately, pypy doesn't work because not all our dependencies seem to work with it.
